### PR TITLE
[doctrine][model] allow store custom values.

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,10 +1,14 @@
 0.6 to 0.7
 ==========
 
-* [Doctrine] `Payum\Paypal\ExpressCheckout\Nvp\Bridge\Doctrine\Entity\PaymentDetails` is deprecated. Use `Payum\Paypal\ExpressCheckout\Nvp\Model\PaymentDetails` model.
-* [Doctrine] `Payum\Paypal\ExpressCheckout\Nvp\Bridge\Doctrine\Entity\RecurringPaymentDetails` is deprecated. Use `Payum\Paypal\ExpressCheckout\Nvp\Model\RecurringPaymentDetails` model.
-* [Doctrine] `Payum\Paypal\ExpressCheckout\Nvp\Bridge\Doctrine\Document\PaymentDetails` is deprecated. Use `Payum\Paypal\ExpressCheckout\Nvp\Model\PaymentDetails` model.
-* [Doctrine] `Payum\Paypal\ExpressCheckout\Nvp\Bridge\Doctrine\Document\RecurringPaymentDetails` is deprecated. Use `Payum\Paypal\ExpressCheckout\Nvp\Model\RecurringPaymentDetails` model.
+* [Model] `BaseModel::toNvp` was removed.
+* [Model] `BaseModel::fromNvp` was removed.
+* [Doctrine] `Payum\Paypal\ExpressCheckout\Nvp\Model\PaymentDetails` require migration. New field `others` is added.
+* [Doctrine] `Payum\Paypal\ExpressCheckout\Nvp\Model\RecurringPaymentDetails` require migration. New field `others` is added.
+* [Doctrine] `Payum\Paypal\ExpressCheckout\Nvp\Bridge\Doctrine\Entity\PaymentDetails` was deprecated and now removed. Use `Payum\Paypal\ExpressCheckout\Nvp\Model\PaymentDetails` instead.
+* [Doctrine] `Payum\Paypal\ExpressCheckout\Nvp\Bridge\Doctrine\Entity\RecurringPaymentDetails` was deprecated and now removed. Use `Payum\Paypal\ExpressCheckout\Nvp\Model\RecurringPaymentDetails` instead.
+* [Doctrine] `Payum\Paypal\ExpressCheckout\Nvp\Bridge\Doctrine\Document\PaymentDetails` was deprecated and now removed. Use `Payum\Paypal\ExpressCheckout\Nvp\Model\PaymentDetails` instead.
+* [Doctrine] `Payum\Paypal\ExpressCheckout\Nvp\Bridge\Doctrine\Document\RecurringPaymentDetails` was deprecated and now removed. Use `Payum\Paypal\ExpressCheckout\Nvp\Model\RecurringPaymentDetails` instead.
 
 0.4 to 0.5
 ==========

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Bridge/Doctrine/Resources/mapping/PaymentDetails.mongodb.xml
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Bridge/Doctrine/Resources/mapping/PaymentDetails.mongodb.xml
@@ -39,5 +39,7 @@
         <field name="returnurl" fieldName="returnurl" type="string" />
 
         <field name="cancelurl" fieldName="cancelurl" type="string" />
+
+        <field name="others" fieldName="others" type="hash" />
     </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Bridge/Doctrine/Resources/mapping/PaymentDetails.orm.xml
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Bridge/Doctrine/Resources/mapping/PaymentDetails.orm.xml
@@ -39,5 +39,7 @@
         <field name="returnurl" column="returnurl" type="string" nullable="true" />
         
         <field name="cancelurl" column="cancelurl" type="string" nullable="true" />
+
+        <field name="others" column="others" type="json_array" nullable="false" />
     </mapped-superclass>
 </doctrine-mapping>

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Bridge/Doctrine/Resources/mapping/RecurringPaymentDetails.mongodb.xml
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Bridge/Doctrine/Resources/mapping/RecurringPaymentDetails.mongodb.xml
@@ -36,5 +36,7 @@
 
         <field name="l_severitycodes" fieldName="l_severitycodennn" type="hash"  />
 
+        <field name="others" fieldName="others" type="hash" />
+
     </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Bridge/Doctrine/Resources/mapping/RecurringPaymentDetails.orm.xml
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Bridge/Doctrine/Resources/mapping/RecurringPaymentDetails.orm.xml
@@ -36,5 +36,7 @@
 
         <field name="l_severitycodennn" column="l_severitycodes" type="array" nullable="true" />
 
+        <field name="others" column="others" type="json_array" nullable="false" />
+
     </mapped-superclass>
 </doctrine-mapping>

--- a/tests/Payum/Paypal/ExpressCheckout/Nvp/Tests/Functional/Bridge/Doctrine/Document/PaymentDetailsTest.php
+++ b/tests/Payum/Paypal/ExpressCheckout/Nvp/Tests/Functional/Bridge/Doctrine/Document/PaymentDetailsTest.php
@@ -48,4 +48,21 @@ class PaymentDetailsTest extends MongoTest
         $this->assertEquals($expectedAmount, $foundInstruction->getPaymentrequestAmt(0));
         $this->assertEquals($expectedAction, $foundInstruction->getPaymentrequestPaymentaction(0));
     }
+
+    /**
+     * @test
+     */
+    public function shouldSaveOthersField()
+    {
+        $paymentDetails = new PaymentDetails;
+        $paymentDetails['foo'] = $expect = 'theFoo';
+
+        $this->dm->persist($paymentDetails);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $foundDetails = $this->dm->find(get_class($paymentDetails), $paymentDetails->getId());
+
+        $this->assertEquals($expect, $foundDetails['foo']);
+    }
 }

--- a/tests/Payum/Paypal/ExpressCheckout/Nvp/Tests/Functional/Bridge/Doctrine/Document/RecurringPaymentDetailsTest.php
+++ b/tests/Payum/Paypal/ExpressCheckout/Nvp/Tests/Functional/Bridge/Doctrine/Document/RecurringPaymentDetailsTest.php
@@ -54,4 +54,25 @@ class RecurringPaymentDetailsTest extends MongoTest
         $this->assertEquals($expectedDescription, $foundInstruction->getDesc());
         $this->assertEquals($expectedError, $foundInstruction->getLErrorcoden(0));
     }
+
+    /**
+     * @test
+     */
+    public function shouldSaveOthersField()
+    {
+        $recurringPaymentDetails = new RecurringPaymentDetails;
+        $recurringPaymentDetails->setToken('aToken');
+        $recurringPaymentDetails->setAmt(10);
+        $recurringPaymentDetails->setDesc('aDesc');
+        $recurringPaymentDetails->setProfileid(123);
+        $recurringPaymentDetails['foo'] = $expect = 'theFoo';
+
+        $this->dm->persist($recurringPaymentDetails);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $foundDetails = $this->dm->find(get_class($recurringPaymentDetails), $recurringPaymentDetails->getId());
+
+        $this->assertEquals($expect, $foundDetails['foo']);
+    }
 }

--- a/tests/Payum/Paypal/ExpressCheckout/Nvp/Tests/Functional/Bridge/Doctrine/Entity/PaymentDetailsTest.php
+++ b/tests/Payum/Paypal/ExpressCheckout/Nvp/Tests/Functional/Bridge/Doctrine/Entity/PaymentDetailsTest.php
@@ -60,4 +60,21 @@ class PaymentDetailsTest extends OrmTest
         $this->assertEquals($expectedAmount, $foundInstruction->getPaymentrequestAmt(0));
         $this->assertEquals($expectedAction, $foundInstruction->getPaymentrequestPaymentaction(0));
     }
+
+    /**
+     * @test
+     */
+    public function shouldSaveOthersField()
+    {
+        $paymentDetails = new PaymentDetails;
+        $paymentDetails['foo'] = $expect = 'theFoo';
+
+        $this->em->persist($paymentDetails);
+        $this->em->flush();
+        $this->em->clear();
+
+        $foundDetails = $this->em->find(get_class($paymentDetails), $paymentDetails->getId());
+
+        $this->assertEquals($expect, $foundDetails['foo']);
+    }
 }

--- a/tests/Payum/Paypal/ExpressCheckout/Nvp/Tests/Functional/Bridge/Doctrine/Entity/RecurringPaymentDetailsTest.php
+++ b/tests/Payum/Paypal/ExpressCheckout/Nvp/Tests/Functional/Bridge/Doctrine/Entity/RecurringPaymentDetailsTest.php
@@ -64,4 +64,25 @@ class RecurringPaymentDetailsTest extends OrmTest
         $this->assertEquals($expectedAmount, $foundInstruction->getAmt());
         $this->assertEquals($expectedDescription, $foundInstruction->getDesc());
     }
+
+    /**
+     * @test
+     */
+    public function shouldSaveOthersField()
+    {
+        $recurringPaymentDetails = new RecurringPaymentDetails;
+        $recurringPaymentDetails->setToken('aToken');
+        $recurringPaymentDetails->setAmt(10);
+        $recurringPaymentDetails->setDesc('aDesc');
+        $recurringPaymentDetails->setProfileid(123);
+        $recurringPaymentDetails['foo'] = $expect = 'theFoo';
+
+        $this->em->persist($recurringPaymentDetails);
+        $this->em->flush();
+        $this->em->clear();
+
+        $foundDetails = $this->em->find(get_class($recurringPaymentDetails), $recurringPaymentDetails->getId());
+
+        $this->assertEquals($expect, $foundDetails['foo']);
+    }
 }

--- a/tests/Payum/Paypal/ExpressCheckout/Nvp/Tests/Model/PaymentDetailsTest.php
+++ b/tests/Payum/Paypal/ExpressCheckout/Nvp/Tests/Model/PaymentDetailsTest.php
@@ -129,9 +129,9 @@ class PaymentDetailsTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldAllowSetStringValue($getter, $setter, $value, $paypalName)
     {
-        $instruction = new PaymentDetails();
+        $details = new PaymentDetails();
 
-        $instruction->$setter($value);
+        $details->$setter($value);
     }
 
     /**
@@ -141,11 +141,11 @@ class PaymentDetailsTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldAllowGetPreviouslySetStringValue($getter, $setter, $value, $paypalName)
     {
-        $instruction = new PaymentDetails();
+        $details = new PaymentDetails();
 
-        $instruction->$setter($value);
+        $details->$setter($value);
 
-        $this->assertEquals($value, $instruction->$getter());
+        $this->assertEquals($value, $details->$getter());
     }
 
     /**
@@ -155,11 +155,11 @@ class PaymentDetailsTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldAllowSetStringValueInArrayWay($getter, $setter, $value, $paypalName)
     {
-        $instruction = new PaymentDetails();
+        $details = new PaymentDetails();
 
-        $instruction[$paypalName] = $value;
+        $details[$paypalName] = $value;
 
-        $this->assertEquals($value, $instruction->$getter());
+        $this->assertEquals($value, $details->$getter());
     }
 
     /**
@@ -169,12 +169,12 @@ class PaymentDetailsTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldAllowGetStringValueInArrayWay($getter, $setter, $value, $paypalName)
     {
-        $instruction = new PaymentDetails();
+        $details = new PaymentDetails();
 
-        $instruction->$setter($value);
+        $details->$setter($value);
 
-        $this->assertTrue(isset($instruction[$paypalName]));
-        $this->assertEquals($value, $instruction[$paypalName]);
+        $this->assertTrue(isset($details[$paypalName]));
+        $this->assertEquals($value, $details[$paypalName]);
     }
 
     /**
@@ -184,12 +184,12 @@ class PaymentDetailsTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldAllowSetAndGetStringValueInArrayWay($getter, $setter, $value, $paypalName)
     {
-        $instruction = new PaymentDetails();
+        $details = new PaymentDetails();
 
-        $instruction[$paypalName] = $value;
+        $details[$paypalName] = $value;
 
-        $this->assertTrue(isset($instruction[$paypalName]));
-        $this->assertEquals($value, $instruction[$paypalName]);
+        $this->assertTrue(isset($details[$paypalName]));
+        $this->assertEquals($value, $details[$paypalName]);
     }
 
     /**
@@ -201,10 +201,10 @@ class PaymentDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $value = 'theValue';
 
-        $instruction = new PaymentDetails();
+        $details = new PaymentDetails();
 
-        $instruction->$setter(0, $value);
-        $instruction->$setter(9, $value);
+        $details->$setter(0, $value);
+        $details->$setter(9, $value);
     }
 
     /**
@@ -216,13 +216,13 @@ class PaymentDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $value = 'theValue';
 
-        $instruction = new PaymentDetails();
+        $details = new PaymentDetails();
 
-        $instruction->$setter(0, $value);
-        $instruction->$setter(9, $value);
+        $details->$setter(0, $value);
+        $details->$setter(9, $value);
 
-        $this->assertEquals($value, $instruction->$getter(0));
-        $this->assertEquals($value, $instruction->$getter(9));
+        $this->assertEquals($value, $details->$getter(0));
+        $this->assertEquals($value, $details->$getter(9));
     }
 
     /**
@@ -232,10 +232,10 @@ class PaymentDetailsTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldGetNullIfNotSetArrayValue($getter, $setter, $paypalName0, $paypalName9)
     {
-        $instruction = new PaymentDetails();
+        $details = new PaymentDetails();
 
-        $this->assertNull($instruction->$getter(0));
-        $this->assertNull($instruction->$getter(9));
+        $this->assertNull($details->$getter(0));
+        $this->assertNull($details->$getter(9));
     }
 
     /**
@@ -251,12 +251,12 @@ class PaymentDetailsTest extends \PHPUnit_Framework_TestCase
             9 => $value
         );
 
-        $instruction = new PaymentDetails();
+        $details = new PaymentDetails();
 
-        $instruction->$setter(0, $value);
-        $instruction->$setter(9, $value);
+        $details->$setter(0, $value);
+        $details->$setter(9, $value);
 
-        $this->assertEquals($expectedResult, $instruction->$getter());
+        $this->assertEquals($expectedResult, $details->$getter());
     }
 
     /**
@@ -268,13 +268,13 @@ class PaymentDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $value = 'theValue';
 
-        $instruction = new PaymentDetails();
+        $details = new PaymentDetails();
 
-        $instruction[$paypalName0] = $value;
-        $instruction[$paypalName9] = $value;
+        $details[$paypalName0] = $value;
+        $details[$paypalName9] = $value;
 
-        $this->assertEquals($value, $instruction->$getter(0));
-        $this->assertEquals($value, $instruction->$getter(9));
+        $this->assertEquals($value, $details->$getter(0));
+        $this->assertEquals($value, $details->$getter(9));
     }
 
     /**
@@ -286,16 +286,16 @@ class PaymentDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $value = 'theValue';
 
-        $instruction = new PaymentDetails();
+        $details = new PaymentDetails();
 
-        $instruction->$setter(0, $value);
-        $instruction->$setter(9, $value);
+        $details->$setter(0, $value);
+        $details->$setter(9, $value);
 
-        $this->assertTrue(isset($instruction[$paypalName0]));
-        $this->assertEquals($value, $instruction[$paypalName0]);
+        $this->assertTrue(isset($details[$paypalName0]));
+        $this->assertEquals($value, $details[$paypalName0]);
 
-        $this->assertTrue(isset($instruction[$paypalName9]));
-        $this->assertEquals($value, $instruction[$paypalName9]);
+        $this->assertTrue(isset($details[$paypalName9]));
+        $this->assertEquals($value, $details[$paypalName9]);
     }
 
     /**
@@ -307,16 +307,16 @@ class PaymentDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $value = 'theValue';
 
-        $instruction = new PaymentDetails();
+        $details = new PaymentDetails();
 
-        $instruction[$paypalName0] = $value;
-        $instruction[$paypalName9] = $value;
+        $details[$paypalName0] = $value;
+        $details[$paypalName9] = $value;
 
-        $this->assertTrue(isset($instruction[$paypalName0]));
-        $this->assertEquals($value, $instruction[$paypalName0]);
+        $this->assertTrue(isset($details[$paypalName0]));
+        $this->assertEquals($value, $details[$paypalName0]);
 
-        $this->assertTrue(isset($instruction[$paypalName9]));
-        $this->assertEquals($value, $instruction[$paypalName9]);
+        $this->assertTrue(isset($details[$paypalName9]));
+        $this->assertEquals($value, $details[$paypalName9]);
     }
 
     /**
@@ -328,10 +328,10 @@ class PaymentDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $value = 'theValue';
 
-        $instruction = new PaymentDetails();
+        $details = new PaymentDetails();
 
-        $instruction->$setter(0, 0, $value);
-        $instruction->$setter(9, 9, $value);
+        $details->$setter(0, 0, $value);
+        $details->$setter(9, 9, $value);
     }
 
     /**
@@ -343,13 +343,13 @@ class PaymentDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $value = 'theValue';
 
-        $instruction = new PaymentDetails();
+        $details = new PaymentDetails();
 
-        $instruction->$setter(0, 0, $value);
-        $instruction->$setter(9, 9, $value);
+        $details->$setter(0, 0, $value);
+        $details->$setter(9, 9, $value);
 
-        $this->assertEquals($value, $instruction->$getter(0, 0));
-        $this->assertEquals($value, $instruction->$getter(9, 9));
+        $this->assertEquals($value, $details->$getter(0, 0));
+        $this->assertEquals($value, $details->$getter(9, 9));
     }
 
     /**
@@ -359,10 +359,10 @@ class PaymentDetailsTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldGetNullIfNotSetMultiArrayValue($getter, $setter, $paypalName0, $paypalName9)
     {
-        $instruction = new PaymentDetails();
+        $details = new PaymentDetails();
 
-        $this->assertNull($instruction->$getter(0, 0));
-        $this->assertNull($instruction->$getter(9, 9));
+        $this->assertNull($details->$getter(0, 0));
+        $this->assertNull($details->$getter(9, 9));
     }
 
     /**
@@ -374,13 +374,13 @@ class PaymentDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $value = 'theValue';
 
-        $instruction = new PaymentDetails();
+        $details = new PaymentDetails();
 
-        $instruction[$paypalName0] = $value;
-        $instruction[$paypalName9] = $value;
+        $details[$paypalName0] = $value;
+        $details[$paypalName9] = $value;
 
-        $this->assertEquals($value, $instruction->$getter(0, 0));
-        $this->assertEquals($value, $instruction->$getter(9, 9));
+        $this->assertEquals($value, $details->$getter(0, 0));
+        $this->assertEquals($value, $details->$getter(9, 9));
     }
 
     /**
@@ -390,19 +390,18 @@ class PaymentDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $value = 0;
 
-        $instruction = new PaymentDetails;
+        $details = new PaymentDetails;
 
-        $instruction['PAYMENTREQUEST_0_AMT'] = $value;
+        $details['PAYMENTREQUEST_0_AMT'] = $value;
 
-        $this->assertEquals($value, $instruction->getPaymentrequestAmt(0));
-        $this->assertEquals($value, $instruction['PAYMENTREQUEST_0_AMT']);
+        $this->assertEquals($value, $details->getPaymentrequestAmt(0));
+        $this->assertEquals($value, $details['PAYMENTREQUEST_0_AMT']);
         
-        $instructionAsArray = iterator_to_array($instruction);
+        $detailsAsArray = iterator_to_array($details);
         
-        $this->assertArrayHasKey('PAYMENTREQUEST_0_AMT', $instructionAsArray);
-        $this->assertEquals($value, $instructionAsArray['PAYMENTREQUEST_0_AMT']);
+        $this->assertArrayHasKey('PAYMENTREQUEST_0_AMT', $detailsAsArray);
+        $this->assertEquals($value, $detailsAsArray['PAYMENTREQUEST_0_AMT']);
     }
-
 
     /**
      * @test
@@ -413,16 +412,16 @@ class PaymentDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $value = 'theValue';
 
-        $instruction = new PaymentDetails();
+        $details = new PaymentDetails();
 
-        $instruction->$setter(0, 0, $value);
-        $instruction->$setter(9, 9, $value);
+        $details->$setter(0, 0, $value);
+        $details->$setter(9, 9, $value);
 
-        $this->assertTrue(isset($instruction[$paypalName0]));
-        $this->assertEquals($value, $instruction[$paypalName0]);
+        $this->assertTrue(isset($details[$paypalName0]));
+        $this->assertEquals($value, $details[$paypalName0]);
 
-        $this->assertTrue(isset($instruction[$paypalName9]));
-        $this->assertEquals($value, $instruction[$paypalName9]);
+        $this->assertTrue(isset($details[$paypalName9]));
+        $this->assertEquals($value, $details[$paypalName9]);
     }
 
     /**
@@ -434,15 +433,34 @@ class PaymentDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $value = 'theValue';
 
-        $instruction = new PaymentDetails();
+        $details = new PaymentDetails();
 
-        $instruction[$paypalName0] = $value;
-        $instruction[$paypalName9] = $value;
+        $details[$paypalName0] = $value;
+        $details[$paypalName9] = $value;
 
-        $this->assertTrue(isset($instruction[$paypalName0]));
-        $this->assertEquals($value, $instruction[$paypalName0]);
+        $this->assertTrue(isset($details[$paypalName0]));
+        $this->assertEquals($value, $details[$paypalName0]);
 
-        $this->assertTrue(isset($instruction[$paypalName9]));
-        $this->assertEquals($value, $instruction[$paypalName9]);
+        $this->assertTrue(isset($details[$paypalName9]));
+        $this->assertEquals($value, $details[$paypalName9]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldAllowSetCustomValue()
+    {
+        $value = 'theValue';
+
+        $details = new PaymentDetails();
+        $details['foo'] = $value;
+
+        $this->assertTrue(isset($details['foo']));
+        $this->assertEquals($value, $details['foo']);
+
+        unset($details['foo']);
+
+        $this->assertFalse(isset($details['foo']));
+        $this->assertNull($details['foo']);
     }
 }

--- a/tests/Payum/Paypal/ExpressCheckout/Nvp/Tests/Model/RecurringPaymentDetailsTest.php
+++ b/tests/Payum/Paypal/ExpressCheckout/Nvp/Tests/Model/RecurringPaymentDetailsTest.php
@@ -136,9 +136,9 @@ class RecurringPaymentDetailsTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldAllowSetStringValue($getter, $setter, $value, $paypalName)
     {
-        $instruction = new RecurringPaymentDetails();
+        $details = new RecurringPaymentDetails();
 
-        $instruction->$setter($value);
+        $details->$setter($value);
     }
 
     /**
@@ -148,11 +148,11 @@ class RecurringPaymentDetailsTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldAllowGetPreviouslySetStringValue($getter, $setter, $value, $paypalName)
     {
-        $instruction = new RecurringPaymentDetails();
+        $details = new RecurringPaymentDetails();
 
-        $instruction->$setter($value);
+        $details->$setter($value);
 
-        $this->assertEquals($value, $instruction->$getter());
+        $this->assertEquals($value, $details->$getter());
     }
 
     /**
@@ -162,11 +162,11 @@ class RecurringPaymentDetailsTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldAllowSetStringValueInArrayWay($getter, $setter, $value, $paypalName)
     {
-        $instruction = new RecurringPaymentDetails();
+        $details = new RecurringPaymentDetails();
 
-        $instruction[$paypalName] = $value;
+        $details[$paypalName] = $value;
 
-        $this->assertEquals($value, $instruction->$getter());
+        $this->assertEquals($value, $details->$getter());
     }
 
     /**
@@ -176,12 +176,12 @@ class RecurringPaymentDetailsTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldAllowGetStringValueInArrayWay($getter, $setter, $value, $paypalName)
     {
-        $instruction = new RecurringPaymentDetails();
+        $details = new RecurringPaymentDetails();
 
-        $instruction->$setter($value);
+        $details->$setter($value);
 
-        $this->assertTrue(isset($instruction[$paypalName]));
-        $this->assertEquals($value, $instruction[$paypalName]);
+        $this->assertTrue(isset($details[$paypalName]));
+        $this->assertEquals($value, $details[$paypalName]);
     }
 
     /**
@@ -191,12 +191,12 @@ class RecurringPaymentDetailsTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldAllowSetAndGetStringValueInArrayWay($getter, $setter, $value, $paypalName)
     {
-        $instruction = new RecurringPaymentDetails();
+        $details = new RecurringPaymentDetails();
 
-        $instruction[$paypalName] = $value;
+        $details[$paypalName] = $value;
 
-        $this->assertTrue(isset($instruction[$paypalName]));
-        $this->assertEquals($value, $instruction[$paypalName]);
+        $this->assertTrue(isset($details[$paypalName]));
+        $this->assertEquals($value, $details[$paypalName]);
     }
 
     /**
@@ -208,10 +208,10 @@ class RecurringPaymentDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $value = 'theValue';
 
-        $instruction = new RecurringPaymentDetails();
+        $details = new RecurringPaymentDetails();
 
-        $instruction->$setter(0, $value);
-        $instruction->$setter(9, $value);
+        $details->$setter(0, $value);
+        $details->$setter(9, $value);
     }
 
     /**
@@ -223,13 +223,13 @@ class RecurringPaymentDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $value = 'theValue';
 
-        $instruction = new RecurringPaymentDetails();
+        $details = new RecurringPaymentDetails();
 
-        $instruction->$setter(0, $value);
-        $instruction->$setter(9, $value);
+        $details->$setter(0, $value);
+        $details->$setter(9, $value);
 
-        $this->assertEquals($value, $instruction->$getter(0));
-        $this->assertEquals($value, $instruction->$getter(9));
+        $this->assertEquals($value, $details->$getter(0));
+        $this->assertEquals($value, $details->$getter(9));
     }
 
     /**
@@ -239,10 +239,10 @@ class RecurringPaymentDetailsTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldGetNullIfNotSetArrayValue($getter, $setter, $paypalName0, $paypalName9)
     {
-        $instruction = new RecurringPaymentDetails();
+        $details = new RecurringPaymentDetails();
 
-        $this->assertNull($instruction->$getter(0));
-        $this->assertNull($instruction->$getter(9));
+        $this->assertNull($details->$getter(0));
+        $this->assertNull($details->$getter(9));
     }
 
     /**
@@ -258,12 +258,12 @@ class RecurringPaymentDetailsTest extends \PHPUnit_Framework_TestCase
             9 => $value
         );
 
-        $instruction = new RecurringPaymentDetails();
+        $details = new RecurringPaymentDetails();
 
-        $instruction->$setter(0, $value);
-        $instruction->$setter(9, $value);
+        $details->$setter(0, $value);
+        $details->$setter(9, $value);
 
-        $this->assertEquals($expectedResult, $instruction->$getter());
+        $this->assertEquals($expectedResult, $details->$getter());
     }
 
     /**
@@ -275,13 +275,13 @@ class RecurringPaymentDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $value = 'theValue';
 
-        $instruction = new RecurringPaymentDetails();
+        $details = new RecurringPaymentDetails();
 
-        $instruction[$paypalName0] = $value;
-        $instruction[$paypalName9] = $value;
+        $details[$paypalName0] = $value;
+        $details[$paypalName9] = $value;
 
-        $this->assertEquals($value, $instruction->$getter(0));
-        $this->assertEquals($value, $instruction->$getter(9));
+        $this->assertEquals($value, $details->$getter(0));
+        $this->assertEquals($value, $details->$getter(9));
     }
 
     /**
@@ -293,16 +293,16 @@ class RecurringPaymentDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $value = 'theValue';
 
-        $instruction = new RecurringPaymentDetails();
+        $details = new RecurringPaymentDetails();
 
-        $instruction->$setter(0, $value);
-        $instruction->$setter(9, $value);
+        $details->$setter(0, $value);
+        $details->$setter(9, $value);
 
-        $this->assertTrue(isset($instruction[$paypalName0]));
-        $this->assertEquals($value, $instruction[$paypalName0]);
+        $this->assertTrue(isset($details[$paypalName0]));
+        $this->assertEquals($value, $details[$paypalName0]);
 
-        $this->assertTrue(isset($instruction[$paypalName9]));
-        $this->assertEquals($value, $instruction[$paypalName9]);
+        $this->assertTrue(isset($details[$paypalName9]));
+        $this->assertEquals($value, $details[$paypalName9]);
     }
 
     /**
@@ -314,16 +314,16 @@ class RecurringPaymentDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $value = 'theValue';
 
-        $instruction = new RecurringPaymentDetails();
+        $details = new RecurringPaymentDetails();
 
-        $instruction[$paypalName0] = $value;
-        $instruction[$paypalName9] = $value;
+        $details[$paypalName0] = $value;
+        $details[$paypalName9] = $value;
 
-        $this->assertTrue(isset($instruction[$paypalName0]));
-        $this->assertEquals($value, $instruction[$paypalName0]);
+        $this->assertTrue(isset($details[$paypalName0]));
+        $this->assertEquals($value, $details[$paypalName0]);
 
-        $this->assertTrue(isset($instruction[$paypalName9]));
-        $this->assertEquals($value, $instruction[$paypalName9]);
+        $this->assertTrue(isset($details[$paypalName9]));
+        $this->assertEquals($value, $details[$paypalName9]);
     }
 
     /**
@@ -335,10 +335,10 @@ class RecurringPaymentDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $value = 'theValue';
 
-        $instruction = new RecurringPaymentDetails();
+        $details = new RecurringPaymentDetails();
 
-        $instruction->$setter(0, 0, $value);
-        $instruction->$setter(9, 9, $value);
+        $details->$setter(0, 0, $value);
+        $details->$setter(9, 9, $value);
     }
 
     /**
@@ -350,13 +350,13 @@ class RecurringPaymentDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $value = 'theValue';
 
-        $instruction = new RecurringPaymentDetails();
+        $details = new RecurringPaymentDetails();
 
-        $instruction->$setter(0, 0, $value);
-        $instruction->$setter(9, 9, $value);
+        $details->$setter(0, 0, $value);
+        $details->$setter(9, 9, $value);
 
-        $this->assertEquals($value, $instruction->$getter(0, 0));
-        $this->assertEquals($value, $instruction->$getter(9, 9));
+        $this->assertEquals($value, $details->$getter(0, 0));
+        $this->assertEquals($value, $details->$getter(9, 9));
     }
 
     /**
@@ -366,10 +366,10 @@ class RecurringPaymentDetailsTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldGetNullIfNotSetMultiArrayValue($getter, $setter, $paypalName0, $paypalName9)
     {
-        $instruction = new RecurringPaymentDetails();
+        $details = new RecurringPaymentDetails();
 
-        $this->assertNull($instruction->$getter(0, 0));
-        $this->assertNull($instruction->$getter(9, 9));
+        $this->assertNull($details->$getter(0, 0));
+        $this->assertNull($details->$getter(9, 9));
     }
 
     /**
@@ -381,13 +381,13 @@ class RecurringPaymentDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $value = 'theValue';
 
-        $instruction = new RecurringPaymentDetails();
+        $details = new RecurringPaymentDetails();
 
-        $instruction[$paypalName0] = $value;
-        $instruction[$paypalName9] = $value;
+        $details[$paypalName0] = $value;
+        $details[$paypalName9] = $value;
 
-        $this->assertEquals($value, $instruction->$getter(0, 0));
-        $this->assertEquals($value, $instruction->$getter(9, 9));
+        $this->assertEquals($value, $details->$getter(0, 0));
+        $this->assertEquals($value, $details->$getter(9, 9));
     }
 
 
@@ -400,16 +400,16 @@ class RecurringPaymentDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $value = 'theValue';
 
-        $instruction = new RecurringPaymentDetails();
+        $details = new RecurringPaymentDetails();
 
-        $instruction->$setter(0, 0, $value);
-        $instruction->$setter(9, 9, $value);
+        $details->$setter(0, 0, $value);
+        $details->$setter(9, 9, $value);
 
-        $this->assertTrue(isset($instruction[$paypalName0]));
-        $this->assertEquals($value, $instruction[$paypalName0]);
+        $this->assertTrue(isset($details[$paypalName0]));
+        $this->assertEquals($value, $details[$paypalName0]);
 
-        $this->assertTrue(isset($instruction[$paypalName9]));
-        $this->assertEquals($value, $instruction[$paypalName9]);
+        $this->assertTrue(isset($details[$paypalName9]));
+        $this->assertEquals($value, $details[$paypalName9]);
     }
 
     /**
@@ -421,15 +421,34 @@ class RecurringPaymentDetailsTest extends \PHPUnit_Framework_TestCase
     {
         $value = 'theValue';
 
-        $instruction = new RecurringPaymentDetails();
+        $details = new RecurringPaymentDetails();
 
-        $instruction[$paypalName0] = $value;
-        $instruction[$paypalName9] = $value;
+        $details[$paypalName0] = $value;
+        $details[$paypalName9] = $value;
 
-        $this->assertTrue(isset($instruction[$paypalName0]));
-        $this->assertEquals($value, $instruction[$paypalName0]);
+        $this->assertTrue(isset($details[$paypalName0]));
+        $this->assertEquals($value, $details[$paypalName0]);
 
-        $this->assertTrue(isset($instruction[$paypalName9]));
-        $this->assertEquals($value, $instruction[$paypalName9]);
+        $this->assertTrue(isset($details[$paypalName9]));
+        $this->assertEquals($value, $details[$paypalName9]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldAllowSetCustomValue()
+    {
+        $value = 'theValue';
+
+        $details = new RecurringPaymentDetails();
+        $details['foo'] = $value;
+
+        $this->assertTrue(isset($details['foo']));
+        $this->assertEquals($value, $details['foo']);
+
+        unset($details['foo']);
+
+        $this->assertFalse(isset($details['foo']));
+        $this->assertNull($details['foo']);
     }
 }


### PR DESCRIPTION
This PR allow store any field even those that does not have mappings.

Since 0.7 this is possible:

``` php
<?php

$details = new PaymentDetails;
$details['foo'] = 'theFoo';

$em->persist($details);
$em->flush();
```

the `theFoo`  will be stored to `others` column in the database.

The real life usecase: before 0.7 to store digital goods fields (L_PAYMENTREQUEST_0_NAME0 for example) you have to provide mapping in your class:

``` php
<?php
/**
 * @ORM\Entity
 */
class PaypalExpressPaymentDetails extends PaymentDetails
{
    /**
     * @ORM\Column(name="id", type="integer")
     * @ORM\Id
     * @ORM\GeneratedValue(strategy="IDENTITY")
     */
    protected $id;

    /**
     * @ORM\Column(type="json_array")
     */
    protected $l_paymentrequest_nnn_qtymmm = array();

    /**
     * @ORM\Column(type="json_array")
     */
    protected $l_paymentrequest_nnn_namemmm = array();

    /**
     * @ORM\Column(type="json_array")
     */
    protected $l_paymentrequest_nnn_descmmm = array();

    /**
     * @ORM\Column(type="json_array")
     */
    protected $l_paymentrequest_nnn_amtmmm = array();

    /**
     * @ORM\Column(type="json_array")
     */
    protected $l_paymentrequest_nnn_itemcategorymmm = array();
}
```

now this fields will be stored to `others` field by default and you still can define mapping 
