### PR TITLE
let the user "Confirm Order on Paypal"

### DIFF
--- a/src/Payum/Paypal/ExpressCheckout/Nvp/Api.php
+++ b/src/Payum/Paypal/ExpressCheckout/Nvp/Api.php
@@ -472,10 +472,14 @@ class Api
     {
         $host = $this->options['sandbox'] ? 'www.sandbox.paypal.com' : 'www.paypal.com';
 
+        //let user decide if they want useraction=commit
+        $useraction = isset($this->options['useraction']) ? '&useraction='.$this->options['useraction'] : '';
+
         return sprintf(
-            'https://%s/cgi-bin/webscr?cmd=_express-checkout&token=%s',
+            'https://%s/cgi-bin/webscr?cmd=_express-checkout&token=%s%s',
             $host,
-            $token
+            $token,
+            $useraction
         );
     }
 


### PR DESCRIPTION
The paypal docs say that user can confirm order on paypal, setting useraction=commit variable on the SetExpressCheckout call
- use-case: https://cms.paypal.com/it/cgi-bin/?cmd=_render-content&content_ID=developer/e_howto_api_ECCustomizing#id0864860D0YK
